### PR TITLE
Enable git plugin to work with ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 MAINTAINER ZZROT LLC <docker@zzrot.com>
 
-RUN apk --no-cache add tini git \
+RUN apk --no-cache add tini git openssh-client \
     && apk --no-cache add --virtual devs tar curl
 
 #Install Caddy Server, and All Middleware


### PR DESCRIPTION
Add openssh-client package to prevent the missing package
to error out, when using the git plugin from caddy.
